### PR TITLE
Add scoped tailwind css

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ This starter repo builds on top of Tailwind in a few useful ways:
 - Removes the preflight and global Tailwind styles/animation presets so that there isn't a conflict with other blocks, plugins, etc.
 - On frontend styles, padding and margins will only be applied if the block doesn't have inline styling (e.g. `.p-4:not([style*="padding"])`). This lets you define a default while letting users override these values. Open an issue for more info.
 
-Read more about TypeScript: https://tailwindcss.com/
+Read more about Tailwind CSS: https://tailwindcss.com/
 
 ### Cypress e2e testing - coming soon!

--- a/README.md
+++ b/README.md
@@ -5,12 +5,25 @@ This is a minimum block plugin template to rapidly get started building WP block
 - Follow me on Twitter: https://twitter.com/kevinbatdorf
 - Sponsor this package: https://github.com/sponsors/KevinBatdorf/
 
-## Rust
+## Features
+### Rust
 Rust is a systems programming language with a strong type system, memory safety, and great documentation. Beyond that it's fun to write and has a great community of helpful developers. Rust also compiles into WebAssembly, letting us utilize the power of systems programming on the web.
 
 Read more about Rust: https://www.rust-lang.org/
 
-## TypeScript
+### TypeScript
 TypeScript is essentially JavaScript with type safety. TypeScript will save you plenty of headaches while writing your code. Ever try to access a JS property on undefined? TypeScript will warn you before you even press save.
 
 Read more about TypeScript: https://www.typescriptlang.org/
+
+### Tailwind CSS (heavily scoped)
+Tailwind CSS is a utility framework designed for rapid building. Rather than maintaining CSS/scss files, you use specific class names directly in your markup, keeping the component logic, layout, and design in one place. You should default to WordPress components and classes when possible, and use Tailwind for everything beyond that.
+
+This starter repo builds on top of Tailwind in a few useful ways:
+- Separates editor and frontend styles and processes them in isolation, keeping the stylesheet size on the frontend to a minimum
+- Removes the preflight and global Tailwind styles/animation presets so that there isn't a conflict with other blocks, plugins, etc.
+- On frontend styles, padding and margins will only be applied if the block doesn't have inline styling (e.g. `.p-4:not([style*="padding"])`). This lets you define a default while letting users override these values. Check the postcss.config.js file to see how it's done.
+
+Read more about TypeScript: https://tailwindcss.com/
+
+### Cypress e2e testing - coming soon!

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Tailwind CSS is a utility framework designed for rapid building. Rather than mai
 This starter repo builds on top of Tailwind in a few useful ways:
 - Separates editor and frontend styles and processes them in isolation, keeping the stylesheet size on the frontend to a minimum
 - Removes the preflight and global Tailwind styles/animation presets so that there isn't a conflict with other blocks, plugins, etc.
-- On frontend styles, padding and margins will only be applied if the block doesn't have inline styling (e.g. `.p-4:not([style*="padding"])`). This lets you define a default while letting users override these values. Check the postcss.config.js file to see how it's done.
+- On frontend styles, padding and margins will only be applied if the block doesn't have inline styling (e.g. `.p-4:not([style*="padding"])`). This lets you define a default while letting users override these values. Open an issue for more info.
 
 Read more about TypeScript: https://tailwindcss.com/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3930,6 +3930,25 @@
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true
 		},
+		"acorn-node": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+			"integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.0.0",
+				"acorn-walk": "^7.0.0",
+				"xtend": "^4.0.2"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				}
+			}
+		},
 		"acorn-walk": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -4077,6 +4096,12 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"arg": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+			"integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+			"dev": true
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -4211,17 +4236,44 @@
 			"dev": true
 		},
 		"autoprefixer": {
-			"version": "10.4.2",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
-			"integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
+			"version": "10.4.4",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
+			"integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.19.1",
-				"caniuse-lite": "^1.0.30001297",
-				"fraction.js": "^4.1.2",
+				"browserslist": "^4.20.2",
+				"caniuse-lite": "^1.0.30001317",
+				"fraction.js": "^4.2.0",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
 				"postcss-value-parser": "^4.2.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.20.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+					"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001317",
+						"electron-to-chromium": "^1.4.84",
+						"escalade": "^3.1.1",
+						"node-releases": "^2.0.2",
+						"picocolors": "^1.0.0"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001319",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+					"integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.4.88",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz",
+					"integrity": "sha512-oA7mzccefkvTNi9u7DXmT0LqvhnOiN2BhSrKerta7HeUC1cLoIwtbf2wL+Ah2ozh5KQd3/1njrGrwDBXx6d14Q==",
+					"dev": true
+				}
 			}
 		},
 		"autosize": {
@@ -4640,6 +4692,12 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
 			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true
+		},
+		"camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
 			"dev": true
 		},
 		"camelcase-keys": {
@@ -5624,6 +5682,12 @@
 				"object-keys": "^1.0.12"
 			}
 		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+			"dev": true
+		},
 		"del": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -5706,10 +5770,27 @@
 			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
 			"dev": true
 		},
+		"detective": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+			"integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+			"dev": true,
+			"requires": {
+				"acorn-node": "^1.6.1",
+				"defined": "^1.0.0",
+				"minimist": "^1.1.1"
+			}
+		},
 		"devtools-protocol": {
 			"version": "0.0.960912",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.960912.tgz",
 			"integrity": "sha512-I3hWmV9rWHbdnUdmMKHF2NuYutIM2kXz2mdXW8ha7TbRlGTVs+PF+PsB5QWvpCek4Fy9B+msiispCfwlhG5Sqg==",
+			"dev": true
+		},
+		"didyoumean": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
 			"dev": true
 		},
 		"diff": {
@@ -5741,6 +5822,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+			"dev": true
+		},
+		"dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
 			"dev": true
 		},
 		"dns-equal": {
@@ -7165,9 +7252,9 @@
 			"dev": true
 		},
 		"fraction.js": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.3.tgz",
-			"integrity": "sha512-pUHWWt6vHzZZiQJcM6S/0PXfS+g6FM4BF5rj9wZyreivhQPdsh5PpE25VtSNxq80wHS5RfY51Ii+8Z0Zl/pmzg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+			"integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
 			"dev": true
 		},
 		"framer-motion": {
@@ -9833,6 +9920,12 @@
 			"integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
 			"dev": true
 		},
+		"object-hash": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+			"integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+			"dev": true
+		},
 		"object-inspect": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -10340,6 +10433,36 @@
 			"integrity": "sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg==",
 			"dev": true
 		},
+		"postcss-import": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.0.2.tgz",
+			"integrity": "sha512-BJ2pVK4KhUyMcqjuKs9RijV5tatNzNa73e/32aBVE/ejYPe37iH+6vAu9WvqUkB5OAYgLHzbSvzHnorybJCm9g==",
+			"dev": true,
+			"requires": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			}
+		},
+		"postcss-js": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+			"integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+			"dev": true,
+			"requires": {
+				"camelcase-css": "^2.0.1"
+			}
+		},
+		"postcss-load-config": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.3.tgz",
+			"integrity": "sha512-5EYgaM9auHGtO//ljHH+v/aC/TQ5LHXtL7bQajNAUBKUVKiYE8rYpFms7+V26D9FncaGe2zwCoPQsFKb5zF/Hw==",
+			"dev": true,
+			"requires": {
+				"lilconfig": "^2.0.4",
+				"yaml": "^1.10.2"
+			}
+		},
 		"postcss-loader": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -10463,6 +10586,15 @@
 			"dev": true,
 			"requires": {
 				"icss-utils": "^5.0.0"
+			}
+		},
+		"postcss-nested": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+			"integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+			"dev": true,
+			"requires": {
+				"postcss-selector-parser": "^6.0.6"
 			}
 		},
 		"postcss-normalize-charset": {
@@ -11102,6 +11234,23 @@
 			"requires": {
 				"array.prototype.flat": "^1.2.1",
 				"global-cache": "^1.2.1"
+			}
+		},
+		"read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+			"dev": true,
+			"requires": {
+				"pify": "^2.3.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
 			}
 		},
 		"read-pkg": {
@@ -12654,6 +12803,58 @@
 				}
 			}
 		},
+		"tailwindcss": {
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.23.tgz",
+			"integrity": "sha512-+OZOV9ubyQ6oI2BXEhzw4HrqvgcARY38xv3zKcjnWtMIZstEsXdI9xftd1iB7+RbOnj2HOEzkA0OyB5BaSxPQA==",
+			"dev": true,
+			"requires": {
+				"arg": "^5.0.1",
+				"chalk": "^4.1.2",
+				"chokidar": "^3.5.3",
+				"color-name": "^1.1.4",
+				"cosmiconfig": "^7.0.1",
+				"detective": "^5.2.0",
+				"didyoumean": "^1.2.2",
+				"dlv": "^1.1.3",
+				"fast-glob": "^3.2.11",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"normalize-path": "^3.0.0",
+				"object-hash": "^2.2.0",
+				"postcss": "^8.4.6",
+				"postcss-js": "^4.0.0",
+				"postcss-load-config": "^3.1.0",
+				"postcss-nested": "5.0.6",
+				"postcss-selector-parser": "^6.0.9",
+				"postcss-value-parser": "^4.2.0",
+				"quick-lru": "^5.1.1",
+				"resolve": "^1.22.0"
+			},
+			"dependencies": {
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"glob-parent": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+					"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.3"
+					}
+				},
+				"quick-lru": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+					"dev": true
+				}
+			}
+		},
 		"tannin": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
@@ -13648,6 +13849,12 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"y18n": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
 		"@types/wordpress__block-editor": "^6.0.5",
 		"@types/wordpress__blocks": "^9.1.1",
 		"@wasm-tool/wasm-pack-plugin": "^1.6.0",
-		"@wordpress/scripts": "^22.0.1"
+		"@wordpress/scripts": "^22.2.1",
+		"autoprefixer": "^10.4.4",
+		"postcss-import": "^14.0.2",
+		"tailwindcss": "^3.0.23"
 	},
 	"dependencies": {
-		"@wordpress/block-editor": "^8.2.0",
-		"@wordpress/blocks": "^11.2.2",
-		"@wordpress/element": "^4.1.1",
-		"@wordpress/i18n": "^4.3.1"
+		"@wordpress/block-editor": "^8.3.1",
+		"@wordpress/blocks": "^11.3.1",
+		"@wordpress/element": "^4.2.1",
+		"@wordpress/i18n": "^4.4.1"
 	}
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,6 +10,9 @@ module.exports = ({ mode, file }) => ({
             content: file.endsWith('editor.css')
                 ? ['./src/editor/*.{ts,tsx}']
                 : ['./src/front/*.{ts,tsx}'],
+            important:
+                tailwind.important +
+                (file.endsWith('editor.css') ? '-editor' : ''),
         }),
         (css) =>
             css.walkRules((rule) => {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,8 @@
 const tailwind = require('./tailwind.config')
 
 module.exports = ({ mode, file }) => ({
+    ident: 'postcss',
+    sourceMap: mode !== 'production',
     plugins: [
         require('postcss-import'),
         require('tailwindcss/nesting'),
@@ -31,7 +33,19 @@ module.exports = ({ mode, file }) => ({
                     }
                 }
             }),
-        require('autoprefixer'),
-        mode === 'production' ? require('cssnano') : () => {},
+        // See: https://github.com/WordPress/gutenberg/blob/trunk/packages/postcss-plugins-preset/lib/index.js
+        require('autoprefixer')({ grid: true }),
+        mode === 'production' &&
+            // See: https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/config/webpack.config.js#L68
+            require('cssnano')({
+                preset: [
+                    'default',
+                    {
+                        discardComments: {
+                            removeAll: true,
+                        },
+                    },
+                ],
+            }),
     ],
 })

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,34 @@
+const tailwind = require('./tailwind.config')
+
+module.exports = ({ mode, file }) => ({
+    plugins: [
+        require('postcss-import'),
+        require('tailwindcss/nesting'),
+        require('tailwindcss')({
+            ...tailwind,
+            // Scope the editor css separately from the frontend css.
+            content: file.endsWith('editor.css')
+                ? ['./src/**/*.{ts,tsx}', '!./src/front/*.{ts,tsx}']
+                : ['./src/front/*.{ts,tsx}'],
+        }),
+        (css) =>
+            css.walkRules((rule) => {
+                // Removes top level TW styles like *::before {}
+                rule.selector.startsWith('*') && rule.remove()
+
+                // This will allow users to override something like
+                // padding within the block styles
+                if (file.endsWith('style.css')) {
+                    // This appends the :not() exception to padding and margins
+                    if (new RegExp('[:]?[^a-z]-?p[a-z]?-.+').test(rule)) {
+                        rule.selector += ':not([style*="padding"])'
+                    }
+                    if (new RegExp('[:]?[^a-z]-?m[a-z]?-.+').test(rule)) {
+                        rule.selector += ':not([style*="margin"])'
+                    }
+                }
+            }),
+        require('autoprefixer'),
+        mode === 'production' ? require('cssnano') : () => {},
+    ],
+})

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,7 +8,7 @@ module.exports = ({ mode, file }) => ({
             ...tailwind,
             // Scope the editor css separately from the frontend css.
             content: file.endsWith('editor.css')
-                ? ['./src/**/*.{ts,tsx}', '!./src/front/*.{ts,tsx}']
+                ? ['./src/editor/*.{ts,tsx}']
                 : ['./src/front/*.{ts,tsx}'],
         }),
         (css) =>

--- a/src/TheBlock.tsx
+++ b/src/TheBlock.tsx
@@ -1,4 +1,0 @@
-import type { Attributes } from '.'
-export const TheBlock = ({ text }: Attributes) => {
-    return <div>{text}</div>
-}

--- a/src/block.json
+++ b/src/block.json
@@ -16,7 +16,7 @@
         "html": false
     },
     "textdomain": "rust-starter",
-    "editorScript": "file:./index.tsx",
-    "editorStyle": "file:./editor/editor.css",
-    "style": "file:./front/style.css"
+    "editorScript": "file:../build/index.js",
+    "editorStyle": "file:../build/index.css",
+    "style": "file:../build/style-index.css"
 }

--- a/src/block.json
+++ b/src/block.json
@@ -16,7 +16,7 @@
         "html": false
     },
     "textdomain": "rust-starter",
-    "editorScript": "file:./index.js",
-    "editorStyle": "file:./index.css",
-    "style": "file:./style-index.css"
+    "editorScript": "file:./index.tsx",
+    "editorStyle": "file:./editor/editor.css",
+    "style": "file:./front/style.css"
 }

--- a/src/editor/Controls.tsx
+++ b/src/editor/Controls.tsx
@@ -29,13 +29,17 @@ export const Controls = ({ attributes, setAttributes }: ControlProps) => {
         <InspectorControls>
             <PanelBody title={__('Settings', 'rust-starter')}>
                 <BaseControl id="get-text">
-                    <Button
-                        isPrimary
-                        onClick={setQuote}
-                        className="bg-red-500 p-2"
-                    >
-                        {__('Get new text', 'rust-starter')}
-                    </Button>
+                    {/* To use TW just wrap the class with your namespace as //
+                    defined in tailwind.config.js file */}
+                    <div className="rust-starter">
+                        <div className="p-4 bg-gray-200 mb-4">
+                            This area built with Tailwind CSS. The button below
+                            will use Rust to process the request.
+                        </div>
+                        <Button isPrimary onClick={setQuote}>
+                            {__('Get new text', 'rust-starter')}
+                        </Button>
+                    </div>
                 </BaseControl>
             </PanelBody>
         </InspectorControls>

--- a/src/editor/Controls.tsx
+++ b/src/editor/Controls.tsx
@@ -2,9 +2,9 @@ import { PanelBody, BaseControl, Button } from '@wordpress/components'
 import { __ } from '@wordpress/i18n'
 import { InspectorControls } from '@wordpress/block-editor'
 import { useEffect } from '@wordpress/element'
-import { useServer } from './hooks/useServer'
-import './styles/editor.scss'
-import type { Attributes } from '.'
+import { useServer } from '../hooks/useServer'
+import type { Attributes } from '..'
+import './editor.css'
 
 interface ControlProps {
     attributes: Attributes
@@ -29,7 +29,11 @@ export const Controls = ({ attributes, setAttributes }: ControlProps) => {
         <InspectorControls>
             <PanelBody title={__('Settings', 'rust-starter')}>
                 <BaseControl id="get-text">
-                    <Button isPrimary onClick={setQuote}>
+                    <Button
+                        isPrimary
+                        onClick={setQuote}
+                        className="bg-red-500 p-2"
+                    >
                         {__('Get new text', 'rust-starter')}
                     </Button>
                 </BaseControl>

--- a/src/editor/Controls.tsx
+++ b/src/editor/Controls.tsx
@@ -29,12 +29,12 @@ export const Controls = ({ attributes, setAttributes }: ControlProps) => {
         <InspectorControls>
             <PanelBody title={__('Settings', 'rust-starter')}>
                 <BaseControl id="get-text">
-                    {/* To use TW just wrap the class with your namespace as //
-                    defined in tailwind.config.js file */}
-                    <div className="rust-starter">
+                    {/* To use TW just wrap the class with your namespace as
+                    defined in tailwind.config.js file, but with -editor appended */}
+                    <div className="rust-starter-editor">
                         <div className="p-4 bg-gray-200 mb-4">
-                            This area built with Tailwind CSS. The button below
-                            will use Rust to process the request.
+                            This area is styled with Tailwind CSS. The button
+                            below will use Rust to process the request.
                         </div>
                         <Button isPrimary onClick={setQuote}>
                             {__('Get new text', 'rust-starter')}

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -2,19 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-.kevinbatdorf-rust-starter {
+.rust-starter {
     --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
     --tw-ring-offset-width: 0px;
     --tw-ring-offset-color: transparent;
     --tw-ring-color: var(--wp-admin-theme-color);
 }
-
-.kevinbatdorf-rust-starter *,
-.kevinbatdorf-rust-starter *:after,
-.kevinbatdorf-rust-starter *:before {
+.rust-starter *,
+.rust-starter *:after,
+.rust-starter *:before {
     box-sizing: border-box;
     border: 0 solid #e5e7eb;
 }
-.wp-block-kevinbatdorf-rust-starter {
-	border: 1px dotted #f00;
-}
+/* Add more styles here specific to the editor only */

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -1,0 +1,20 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.kevinbatdorf-rust-starter {
+    --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+    --tw-ring-offset-width: 0px;
+    --tw-ring-offset-color: transparent;
+    --tw-ring-color: var(--wp-admin-theme-color);
+}
+
+.kevinbatdorf-rust-starter *,
+.kevinbatdorf-rust-starter *:after,
+.kevinbatdorf-rust-starter *:before {
+    box-sizing: border-box;
+    border: 0 solid #e5e7eb;
+}
+.wp-block-kevinbatdorf-rust-starter {
+	border: 1px dotted #f00;
+}

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .rust-starter {
     --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
     --tw-ring-offset-width: 0px;
@@ -14,4 +10,7 @@
     box-sizing: border-box;
     border: 0 solid #e5e7eb;
 }
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 /* Add more styles here specific to the editor only */

--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -1,12 +1,12 @@
-.rust-starter {
+.rust-starter-editor {
     --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
     --tw-ring-offset-width: 0px;
     --tw-ring-offset-color: transparent;
     --tw-ring-color: var(--wp-admin-theme-color);
 }
-.rust-starter *,
-.rust-starter *:after,
-.rust-starter *:before {
+.rust-starter-editor *,
+.rust-starter-editor *:after,
+.rust-starter-editor *:before {
     box-sizing: border-box;
     border: 0 solid #e5e7eb;
 }

--- a/src/front/TheBlock.tsx
+++ b/src/front/TheBlock.tsx
@@ -1,0 +1,6 @@
+import type { Attributes } from '..'
+import './style.css'
+
+export const TheBlock = ({ text }: Attributes) => {
+    return <div className="p-2">{text}</div>
+}

--- a/src/front/TheBlock.tsx
+++ b/src/front/TheBlock.tsx
@@ -2,5 +2,11 @@ import type { Attributes } from '..'
 import './style.css'
 
 export const TheBlock = ({ text }: Attributes) => {
-    return <div className="p-2">{text}</div>
+    return (
+        <div className="rust-starter">
+            <div className="p-4 py-8 text-xl text-white bg-indigo-500 shadow-lg">
+                {text}
+            </div>
+        </div>
+    )
 }

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -2,20 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-.kevinbatdorf-rust-starter {
+.rust-starter {
     --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
     --tw-ring-offset-width: 0px;
     --tw-ring-offset-color: transparent;
     --tw-ring-color: var(--wp-admin-theme-color);
 }
-.kevinbatdorf-rust-starter *,
-.kevinbatdorf-rust-starter *:after,
-.kevinbatdorf-rust-starter *:before {
+.rust-starter *,
+.rust-starter *:after,
+.rust-starter *:before {
     box-sizing: border-box;
     border: 0 solid #e5e7eb;
 }
-.wp-block-kevinbatdorf-rust-starter {
-	background-color: #21759b;
-	color: #fff;
-	padding: 2px;
-}
+/* Add more styles here specific to the block/frontend */

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -2,7 +2,7 @@
     --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
     --tw-ring-offset-width: 0px;
     --tw-ring-offset-color: transparent;
-    --tw-ring-color: var(--wp-admin-theme-color);
+    /* --tw-ring-color: you-may-want-to-update-this; */
 }
 .rust-starter *,
 .rust-starter *:after,

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .rust-starter {
     --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
     --tw-ring-offset-width: 0px;
@@ -14,4 +10,7 @@
     box-sizing: border-box;
     border: 0 solid #e5e7eb;
 }
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 /* Add more styles here specific to the block/frontend */

--- a/src/front/style.css
+++ b/src/front/style.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.kevinbatdorf-rust-starter {
+    --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+    --tw-ring-offset-width: 0px;
+    --tw-ring-offset-color: transparent;
+    --tw-ring-color: var(--wp-admin-theme-color);
+}
+.kevinbatdorf-rust-starter *,
+.kevinbatdorf-rust-starter *:after,
+.kevinbatdorf-rust-starter *:before {
+    box-sizing: border-box;
+    border: 0 solid #e5e7eb;
+}
+.wp-block-kevinbatdorf-rust-starter {
+	background-color: #21759b;
+	color: #fff;
+	padding: 2px;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,9 @@
 import { registerBlockType } from '@wordpress/blocks'
 import { useBlockProps as blockProps } from '@wordpress/block-editor'
 import { __ } from '@wordpress/i18n'
-import { TheBlock } from './TheBlock'
-import { Controls } from './Controls'
+import { TheBlock } from './front/TheBlock'
+import { Controls } from './editor/Controls'
 import blockConfig from './block.json'
-import './styles/style.scss'
 
 export type Attributes = {
     text: string

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -1,3 +1,0 @@
-.wp-block-kevinbatdorf-rust-starter {
-	border: 1px dotted #f00;
-}

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,5 +1,0 @@
-.wp-block-kevinbatdorf-rust-starter {
-	background-color: #21759b;
-	color: #fff;
-	padding: 2px;
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,55 @@
+module.exports = {
+    // See postcss.config.js for more parsing options.
+    important: '.kevinbatdorf-rust-starter',
+    theme: {
+        screens: {
+            xxs: '280px',
+            xs: '480px',
+            sm: '600px',
+            md: '782px',
+            md2: '960px', // admin sidebar auto folds
+            lg: '1080px', // adminbar goes big
+            xl: '1280px',
+            '2xl': '1440px',
+            '3xl': '1600px',
+            '4xl': '1920px',
+        },
+        extend: {
+            'wp-theme': {
+                500: 'var(--wp-admin-theme-color)',
+                600: 'var(--wp-admin-theme-color-darker-10)',
+                700: 'var(--wp-admin-theme-color-darker-20)',
+            },
+            wp: {
+                alert: {
+                    yellow: '#f0b849',
+                    red: '#cc1818',
+                    green: '#4ab866',
+                },
+            },
+            // https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_colors.scss
+            gray: {
+                50: '#fbfbfb',
+                100: '#f0f0f0',
+                150: '#eaeaea', // This wasn't a variable but I saw it on buttons
+                200: '#e0e0e0', // Used sparingly for light borders.
+                300: '#dddddd', // Used for most borders.
+                400: '#cccccc',
+                500: '#cccccc',
+                600: '#949494', // Meets 3:1 UI or large text contrast against white.
+                700: '#757575', // Meets 4.6:1 text contrast against white.
+                900: '#1e1e1e',
+            },
+        },
+        zIndex: {
+            high: '99999',
+            max: '2147483647', // max int values - don't block WP re-auth modal
+        },
+    },
+    plugins: [],
+    corePlugins: {
+        preflight: false,
+        animation: false,
+        container: false,
+    },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
+// See postcss.config.js for more parsing options.
 module.exports = {
-    // See postcss.config.js for more parsing options.
-    important: '.kevinbatdorf-rust-starter',
+    // Tnis should match the namespace you use in your css styles.
+    important: '.rust-starter',
     theme: {
         screens: {
             xxs: '280px',


### PR DESCRIPTION
This adds scoped Tailwind. I say scoped as I've removed the global stuff so it won't conflict with other plugins, or WP itself, while maintaining the important bits. 

I've also added the following:

- Creates two separate stylesheets that monitor the frontend and the editor files in isolation. This keeps the bloat out of the front end stylesheet.
- Applies low specificity modifiers to margin/padding, so inline styles on the block will override them. So you can place a default with `p-4` that will transform to `.p-4:not([style*="padding"])`, letting the WP controls override your default styling. Open an issue if you want to know how to add others. 