### PR TITLE
Use wp-cli for plugin install e2e

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -17,8 +17,7 @@ import {
 	visitAdminPage,
 	visitToLoginPage,
 } from './navigate-pages';
-import { installPlugin, uninstallPlugin } from './plugins';
-import { resetDatabase } from './wp-cli';
+import { installPlugin, uninstallPlugin, resetDatabase } from './wp-cli';
 
 // Port more commands from WP here:
 // https://github.com/WordPress/gutenberg/tree/trunk/packages/e2e-test-utils/src

--- a/cypress/support/wp-cli.js
+++ b/cypress/support/wp-cli.js
@@ -1,1 +1,9 @@
 export const resetDatabase = () => cy.exec('wp-env clean all');
+export const installPlugin = (slug) =>
+	cy.exec(`wp-env run cli plugin install ${slug}`, {
+		failOnNonZeroExit: false,
+	});
+export const uninstallPlugin = (slug) =>
+	cy.exec(`wp-env run cli plugin uninstall ${slug}`, {
+		failOnNonZeroExit: false,
+	});


### PR DESCRIPTION
This just updates the install and delete plugin helpers (for e2e tests) to use wp-cli